### PR TITLE
feat: Configure Vite API proxy for development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
-VITE_API_BASE_URL=http://localhost:3000
+# Base URL for the API
+VITE_API_BASE_URL=http://127.0.0.1:5173/api
+
+# Proxy URL only used in development mode
+# The Vite dev server will proxy requests to this URL
+VITE_API_PROXY_TARGET=http://127.0.0.1:3000

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,32 @@
 import react from '@vitejs/plugin-react-swc'
 import path from 'path'
-import { defineConfig } from 'vite'
+import { type UserConfig, defineConfig } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
-// https://vite.dev/config/
-export default defineConfig({
+const baseConfig: UserConfig = {
   plugins: [react(), tsconfigPaths()],
   resolve: {
     alias: {
       '@styles': path.resolve(__dirname, './src/styles'),
     },
   },
-})
+}
+
+const devConfig: UserConfig = {
+  ...baseConfig,
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_PROXY_TARGET,
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
+}
+
+const prodConfig: UserConfig = baseConfig
+
+export default defineConfig(({ command }) =>
+  command === 'serve' ? devConfig : prodConfig,
+)


### PR DESCRIPTION
### 내용

- `VITE_API_PROXY_TARGET` 환경변수를 추가합니다. 백엔드가 실행되고 있는 URL을 적습니다.
- 로컬 환경에서 개발 시 `/api` 경로로 요청을 프로시합니다.
- 위 설정으로 로컬 환경에서 개발 시 쿠키가 설정되지 않는 문제를 해결합니다.